### PR TITLE
add missing create-key task

### DIFF
--- a/tasks/create-key.ts
+++ b/tasks/create-key.ts
@@ -1,0 +1,29 @@
+import hre from "hardhat";
+import { task } from "hardhat/config";
+import "@nomiclabs/hardhat-waffle";
+
+// follows ETH/BTC's BIP 39 protocol
+// https://iancoleman.io/bip39/
+// and matches the one hardhat uses when using { accounts: { mnemonic }}
+task(
+  "create-key",
+  "creates an ETH private / public key pair that can be used for EOAs"
+)
+  .addParam(
+    "mnemonic",
+    "The mnemonic used for BIP39 key derivation: See https://iancoleman.io/bip39"
+  )
+  .setAction(async function (taskArgs, hre, runSuper) {
+    console.log("Hello, World!", taskArgs);
+    const { mnemonic } = taskArgs;
+    const masterKey = hre.ethers.utils.HDNode.fromMnemonic(mnemonic);
+    
+    console.log(masterKey)
+    // "m/44'/60'/0'/0/0" first account
+    const getPathForIndex = (index:number) => `m/44'/60'/0'/0/${index}`
+
+    Array.from({ length: 5 }).forEach((_, index) => {
+      const key = masterKey.derivePath(getPathForIndex(index));
+      console.log(`Key ${getPathForIndex(index)}: ${key.address} (PK: ${key.publicKey}) (sk: ${key.privateKey})`)
+    })
+  });

--- a/tasks/index.ts
+++ b/tasks/index.ts
@@ -1,6 +1,6 @@
 // for hardhat to pick up these tasks, they need to be imported like this
 // not with 'import * as tasks from ...'
 import './accounts';
+import './create-key';
 import './get-code';
 import './hashcash';
-


### PR DESCRIPTION
Copied the file [tasks/create-key.ts](https://github.com/MrToph/capture-the-ether/blob/master/tasks/create-key.ts) from [MrToph/capture-the-ether](https://github.com/MrToph/capture-the-ether).

- [x] Imported the task in alphabetical order to respect the existing format
- [x] Running the task was successful
- [x] Resolves issue https://github.com/MrToph/paradigm-ctf/issues/1